### PR TITLE
added a podspec file and a LICENSE

### DIFF
--- a/ICETutorial.podspec
+++ b/ICETutorial.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'ICETutorial'
+  s.version = '1.0.2'
+  s.summary = 'An implementation of the in-app tutorial as seen e.g. in Path 3'
+  s.homepage = 'http://icepat.github.io/ICETutorial'
+  s.license = {
+    :type => 'MIT',
+    :file => 'LICENSE'
+  }
+  s.author = 'Patrick Trillsam'
+  s.source = {
+    :git => 'https://github.com/DaGaMs/ICETutorial.git',
+    :tag => '1.0.2'
+  }
+  s.platform = :ios, '6.0'
+  s.source_files = 'ICETutorial/Libraries'
+  s.public_header_files = 'ICETutorial/Libraries'
+  s.frameworks = 'UIKit', 'CoreGraphics'
+  s.requires_arc = true
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright (c) 2013 Patrick Trillsam - ICETutorial
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I'm using cocoapods for my dependencies so I added the necessary file. You need to change the url in the "git" field of the podspec to your repository, otherwise it should be good to go. You can then contribute the repo to the cocoapods repository so ICETutorial will show up in searches on cocoapods.org
