### PR TITLE
Add labels to scrollview only once.

### DIFF
--- a/ICETutorial/Libraries/ICETutorialController.m
+++ b/ICETutorial/Libraries/ICETutorialController.m
@@ -244,7 +244,6 @@
     else
         [overlayLabel setTextColor:[commonStyle textColor]];
   
-    [_scrollView addSubview:overlayLabel];
     return overlayLabel;
 }
 


### PR DESCRIPTION
All labels were added to the scrollview twice (setOverlayTexts adds labels returned from overlayLabelWithText:layer:commonStyle:index: but they were already being added there).
