### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A nice tutorial like the one introduced in the Path 3.X App (in Swift)
 Questions or ideas : patrick.trillsam@gmail.com.
 
 
-###License :
+### License :
 
 The MIT License
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
